### PR TITLE
Tokenize and parse whitespace

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -98,6 +98,8 @@ class BaseApacheConfigLexer(object):
         'CLOSE_TAG',
         'OPEN_CLOSE_TAG',
         'OPTION_AND_VALUE',
+        'WHITESPACE',
+        'NEWLINE',
     )
 
     states = (
@@ -161,7 +163,7 @@ class BaseApacheConfigLexer(object):
             raise ApacheConfigError(
                 'Syntax error in option-value pair %s on line '
                 '%d' % (token, lineno))
-        option, value = re.split(r'[ \n\r\t=]+', token, maxsplit=1)
+        option, middle, value = re.split(r'([ \n\r\t=]+)', token, maxsplit=1)
         if not option:
             raise ApacheConfigError(
                 'Syntax error in option-value pair %s on line '
@@ -174,7 +176,7 @@ class BaseApacheConfigLexer(object):
                 value = SingleQuotedString(stripped[1:-1])
         if '#' in value:
             value = value.replace('\\#', '#')
-        return option, value
+        return option, middle, value
 
     def _pre_parse_value(self, option, value):
         try:
@@ -185,7 +187,7 @@ class BaseApacheConfigLexer(object):
             return True, option, value
 
     def t_OPTION_AND_VALUE(self, t):
-        r'[^ \n\r\t=#]+[ \t=]+[^\r\n#]+'  # TODO(etingof) escape hash
+        r'[^ \n\r\t=#]+([ \t=]+[^ \t\n\r#]+)+'  # TODO(etingof) escape hash
         if t.value.endswith('\\'):
             t.lexer.multiline_newline_seen = False
             t.lexer.code_start = t.lexer.lexpos - len(t.value)
@@ -194,7 +196,7 @@ class BaseApacheConfigLexer(object):
 
         lineno = len(re.findall(r'\r\n|\n|\r', t.value))
 
-        option, value = self._parse_option_value(t.value, t.lineno)
+        option, whitespace, value = self._parse_option_value(t.value, t.lineno)
 
         process, option, value = self._pre_parse_value(option, value)
         if not process:
@@ -203,11 +205,12 @@ class BaseApacheConfigLexer(object):
         if value.startswith('<<'):
             t.lexer.heredoc_anchor = value[2:].strip()
             t.lexer.heredoc_option = option
-            t.lexer.code_start = t.lexer.lexpos
+            t.lexer.heredoc_whitespace = whitespace
+            t.lexer.code_start = t.lexer.lexpos + 1
             t.lexer.begin('heredoc')
             return
 
-        t.value = option, value
+        t.value = option, whitespace, value
 
         t.lexer.lineno += lineno
 
@@ -224,16 +227,18 @@ class BaseApacheConfigLexer(object):
         t.lexer.begin('INITIAL')
 
         value = t.lexer.lexdata[t.lexer.code_start:t.lexer.lexpos + 1]
+        value = self._remove_trailing_whitespace(value)
+        t.lexer.lexpos = t.lexer.code_start + len(value)
         t.lexer.lineno += len(re.findall(r'\r\n|\n|\r', value))
-        value = value.replace('\\\n', '').replace('\r', '').replace('\n', '')
+        value = re.sub(r'(\\\n|\r|\n)', '', value)
 
-        option, value = self._parse_option_value(value, t.lineno)
+        option, whitespace, value = self._parse_option_value(value, t.lineno)
 
         process, option, value = self._pre_parse_value(option, value)
         if not process:
             return
 
-        t.value = option, value
+        t.value = option, whitespace, value
 
         return t
 
@@ -248,6 +253,16 @@ class BaseApacheConfigLexer(object):
             "Illegal character '%s' in multi-line text on line "
             "%d" % (t.value[0], t.lineno))
 
+    def _remove_trailing_whitespace(self, value):
+        # if stripped_value ends with an odd number of backslashes, the first
+        # trailing whitespace character was escaped and should be included in `value`
+        def trailing_escape(s):
+            return (len(s) - len(s.rstrip('\\'))) % 2 == 1
+        value = value.rstrip()
+        while trailing_escape(value):
+            value = value[:-1].rstrip()
+        return value
+
     def t_heredoc_OPTION_AND_VALUE(self, t):
         r'[^\r\n]+'
         if t.value.lstrip() != t.lexer.heredoc_anchor:
@@ -256,11 +271,11 @@ class BaseApacheConfigLexer(object):
         t.type = "OPTION_AND_VALUE"
         t.lexer.begin('INITIAL')
 
-        value = t.lexer.lexdata[t.lexer.code_start + 1:t.lexer.lexpos - len(t.lexer.heredoc_anchor)]
-
+        value = t.lexer.lexdata[t.lexer.code_start:t.lexer.lexpos - len(t.lexer.heredoc_anchor)]
+        value = self._remove_trailing_whitespace(value)
         t.lexer.lineno += len(re.findall(r'\r\n|\n|\r', t.value))
 
-        t.value = t.lexer.heredoc_option, value
+        t.value = t.lexer.heredoc_option, t.lexer.heredoc_whitespace, value
 
         return t
 
@@ -273,13 +288,15 @@ class BaseApacheConfigLexer(object):
             "Illegal character '%s' in here-document text on line "
             "%d" % (t.value[0], t.lineno))
 
-    def t_WHITESPACE(self, t):
-        r'[ \t]+'
-
     def t_NEWLINE(self, t):
-        r'\r\n|\n|\r|\\'
+        r'[ \t]*((\r\n|\n|\r|\\)[\t ]*)+'
         if t.value != '\\':
             t.lexer.lineno += 1
+        return t
+
+    def t_WHITESPACE(self, t):
+        r'[ \t]+'
+        return t
 
     def t_error(self, t):
         raise ApacheConfigError(

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -74,12 +74,24 @@ class BaseApacheConfigParser(object):
         self.reset()
         return self.engine.parse(text)
 
-    # Parsing rules
+    # PARSING RULES
+    # =============
+
+    def p_requirednewline(self, p):
+        """requirednewline : NEWLINE
+        """
+        p[0] = p[1:][0]
+
+    def p_whitespace(self, p):
+        """whitespace : requirednewline
+                      | WHITESPACE
+        """
+        p[0] = p[1:][0]
 
     def p_statement(self, p):
         """statement : OPTION_AND_VALUE
         """
-        p[0] = ['statement', p[1][0], p[1][1]]
+        p[0] = ['statement', p[1][0], p[1][2]]
 
         if self.options.get('lowercasenames'):
             p[0][1] = p[0][1].lower()
@@ -89,35 +101,70 @@ class BaseApacheConfigParser(object):
                 not hasattr(p[0][2], 'is_double_quoted')):
             p[0][2] = p[0][2].rstrip()
 
+    # Note: item vs comment
+    # ---------------------
+    # `item` and `comment` are differentiated since there can be in-line
+    # comments. Comments do not necessarily need a newline to separate it
+    # from a previous item, but an item needs a newline to
+    # separate it from a previous item or comment.
+
     def p_item(self, p):
         """item : statement
-                | comment
                 | include
                 | includeoptional
                 | block
         """
         p[0] = p[1:][0]
 
+    def p_startitem(self, p):
+        """startitem : whitespace item
+                     | whitespace comment
+                     | item
+                     | comment
+        """
+        if len(p) == 3:
+            p[0] = p[1:][1]
+        else:
+            p[0] = p[1:][0]
+
+    def p_miditem(self, p):
+        """miditem : requirednewline item
+                   | whitespace comment
+                   | comment
+        """
+        if len(p) == 3:
+            p[0] = p[1:][1]
+        else:
+            p[0] = p[1:][0]
+
     def p_contents(self, p):
-        """contents : contents item
-                    | item
+        """contents : contents miditem
+                    | contents whitespace
+                    | startitem
+                    | whitespace
         """
         n = len(p)
         if n == 3:
-            p[0] = p[1] + [p[2]]
+            if isinstance(p[2], str) and p[2].isspace():
+                p[0] = p[1]
+            else:
+                p[0] = p[1] + [p[2]]
         else:
-            p[0] = ['contents', p[1]]
+            if isinstance(p[1], str) and p[1].isspace():
+                p[0] = ['contents', []]
+            else:
+                p[0] = ['contents', p[1]]
 
     def p_block(self, p):
         """block : OPEN_TAG contents CLOSE_TAG
-                 | OPEN_TAG CLOSE_TAG
+                 | OPEN_TAG requirednewline CLOSE_TAG
                  | OPEN_CLOSE_TAG
         """
         n = len(p)
         if n == 4:
+            if isinstance(p[2], str) and p[2].isspace():
+                p[2] = []
             p[0] = ['block', p[1], p[2], p[3]]
-        elif n == 3:
-            p[0] = ['block', p[1],  [], p[2]]
         else:
             p[0] = ['block', p[1], [], p[1]]
 

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -21,8 +21,9 @@ class LexerTestCase(unittest.TestCase):
         self.lexer = ApacheConfigLexer()
 
     def test_whitespace(self):
-        tokens = self.lexer.tokenize('   \t\t  \t \r  \n\n')
-        self.assertFalse(tokens)
+        space = '   \t\t  \t \r  \n\n'
+        tokens = self.lexer.tokenize(space)
+        self.assertEqual(tokens, [space])
 
     def testOptionAndValueSet(self):
         text = """\
@@ -36,9 +37,9 @@ a "b"
 a = "b"
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, [('a', 'b'), ('a', 'b'), ('a', 'b'),
-                                  ('a', 'b'), ('a', 'b'), ('a', 'b'),
-                                  ('a', 'b'), ('a', 'b')])
+        self.assertEqual(tokens, [('a', ' ',  'b'), '\n', ('a', ' = ', 'b'), '\n', ('a','    ', 'b'), '\n',
+                                  ('a', '= ', 'b'), '\n', ('a',' =', 'b'),'\n', ('a','   ', 'b'),'\n',
+                                  ('a', ' ', 'b'), '\n', ('a', ' = ','b'), '\n'])
 
     def testLiteralTags(self):
         text = """\
@@ -46,7 +47,7 @@ a = "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['a', 'a'])
+        self.assertEqual(tokens, ['a', '\n', 'a', '\n'])
 
     def testExpressionTags(self):
         text = """\
@@ -54,7 +55,7 @@ a = "b"
     </if>
     """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['if a == 1', 'if'])
+        self.assertEqual(tokens, ['    ', 'if a == 1', '\n    ', 'if', '\n    '])
 
     def testComments(self):
         text = """\
@@ -64,7 +65,7 @@ a = "b"
 # a b
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['', ' a', 'a', ' a b'])
+        self.assertEqual(tokens, ['', '\n', ' a', '\n', 'a', '\n', ' a b', '\n'])
 
     def testBlockOptionsAndValues(self):
         text = """\
@@ -77,7 +78,7 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['a', ('a', 'b'), ('a', 'b'), ('a', 'b'), ('a', 'b'), ('a', 'b'), 'a'])
+        self.assertEqual(tokens, ['a', '\n', ('a', ' ', 'b'), '\n', ('a', '=', 'b'), '\n', ('a', ' =  ', 'b'), '\n', ('a', ' = ', 'b'), '\n', ('a',' ', 'b'), '\n', 'a', '\n'])
 
     def testBlockComments(self):
         text = """\
@@ -88,7 +89,7 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['a', '', ' a', ' a b', 'a'])
+        self.assertEqual(tokens, ['a', '\n', '', '\n', ' a', '\n', ' a b', '\n', 'a', '\n'])
 
     def testBlockBlankLines(self):
         text = """\
@@ -98,7 +99,7 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['a', 'a'])
+        self.assertEqual(tokens, ['a', '\n\n\n', 'a', '\n'])
 
     def testIncludesConfigGeneral(self):
         text = """\
@@ -108,7 +109,7 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['first.conf', 'a', 'second.conf', 'a'])
+        self.assertEqual(tokens, ['first.conf', '\n', 'a', '\n', 'second.conf', '\n', 'a', '\n'])
 
     def testIncludesApache(self):
         text = """\
@@ -118,7 +119,15 @@ Include second.conf
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['first.conf', 'a', 'second.conf', 'a'])
+        self.assertEqual(tokens, ['first.conf', '\n', 'a', '\n', 'second.conf', '\n', 'a', '\n'])
+
+    def testMultilineOption(self):
+        text = """\
+a \\
+c b  \\
+  """
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(tokens, [('a', ' ', 'c b'), '  \\\n  '])
 
     def testConfiguration(self):
         text = """\
@@ -129,7 +138,7 @@ a = b
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, [' h', ('a', 'b'), 'a', ('a', 'b'), 'a'])
+        self.assertEqual(tokens, [' h', '\n', ('a', ' = ', 'b'), '\n', 'a', '\n  ', ('a', ' ', 'b'), '\n', 'a', '\n'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -23,13 +23,13 @@ class ParserTestCase(unittest.TestCase):
 
         parser = ApacheConfigParser(ApacheConfigLexer(), start='statement')
 
-        ast = parser.parse('a b\n')
+        ast = parser.parse('a b')
         self.assertEqual(ast, ['statement', 'a', 'b'])
 
-        ast = parser.parse('a=b\n')
+        ast = parser.parse('a=b')
         self.assertEqual(ast, ['statement', 'a', 'b'])
 
-        ast = parser.parse('a "b c"\n')
+        ast = parser.parse('a "b c"')
         self.assertEqual(ast, ['statement', 'a', 'b c'])
 
     def testHashComments(self):
@@ -151,8 +151,7 @@ a "b"
   a = "b b"
   # a b
   a = "b b"
-</a>
-"""
+</a>"""
         ApacheConfigLexer = make_lexer()
         ApacheConfigParser = make_parser()
 
@@ -173,8 +172,7 @@ a "b"
      <c>
      </c>
   </b>
-</a>
-"""
+</a>"""
             ApacheConfigLexer = make_lexer()
             ApacheConfigParser = make_parser()
 
@@ -290,6 +288,16 @@ a "b"
                                   ]
                                  ],
                                 'main']])
+
+    def testEmptyConfig(self):
+        text = " "
+        ApacheConfigLexer = make_lexer()
+        ApacheConfigParser = make_parser()
+
+        parser = ApacheConfigParser(ApacheConfigLexer(), start='config')
+
+        ast = parser.parse(text)
+        self.assertEqual(ast, ['config', ['contents', []]])
 
     def testWholeConfig(self):
         text = """\


### PR DESCRIPTION
Should leave all functionality the same.

PR maintains all prior functionality (parser understands, but throws away whitespace information)-- except `nostrip` flag. Now that we're consuming whitespace during lexing rather than parsing, the `nostrip` flag must be implemented at the lexing layer.